### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ more means that your are close to fix your GPS position on the board and know cu
 ![Screenshot 2](https://lh3.googleusercontent.com/4rFNH8ZmAlsdpRn-wnivYOsx7xm5BApS8sFLWRgq6l3BXypGK-rQ_66FC-vnzWu0mgU=h310-rw)
 ![Screenshot 3](https://lh3.googleusercontent.com/ZFN44OByxTpCoxnq5GM2qtjlg0mD2ykflBnzX-hGSax2vGHfA3B_6SlhztAct9VU-DY=h310-rw)
 
-Feel free to review my code, send feedback or sugestions.
+Feel free to review my code, send feedback or suggestions.
 
 <a href='https://play.google.com/store/apps/details?id=kniezrec.com.flightinfo&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png'/></a>


### PR DESCRIPTION
## Summary
- fix a minor typo in README

## Testing
- `grep -n "sugestions" -i README.md`

------
https://chatgpt.com/codex/tasks/task_e_683ff5f2bb1c8329ae652f232858d934