### PR TITLE
Fix context traversal in findContextOfType

### DIFF
--- a/app/src/main/java/kniezrec/com/flightinfo/common/SmartFlighAppExtensions.kt
+++ b/app/src/main/java/kniezrec/com/flightinfo/common/SmartFlighAppExtensions.kt
@@ -41,11 +41,11 @@ fun String.fromHtml(): CharSequence {
 }
 
 fun <T> Context.findContextOfType(clazz: Class<out T>): T? {
-    var ctx = this
-    while (!clazz.isInstance(this)) {
-        if (this is ContextWrapper) {
-            val baseContext = this.baseContext
-            if (this === baseContext) {
+    var ctx: Context = this
+    while (!clazz.isInstance(ctx)) {
+        if (ctx is ContextWrapper) {
+            val baseContext = ctx.baseContext
+            if (ctx === baseContext) {
                 return null
             } else {
                 ctx = baseContext


### PR DESCRIPTION
## Summary
- fix bug in `findContextOfType` by referencing the loop variable rather than `this`

## Testing
- `./gradlew tasks --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_683ff5f521c48329a98221377edbd579